### PR TITLE
Macでも二重引用符を使わずにinstaller.shに~/.cache/deinを渡せるようにした。

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -281,7 +281,7 @@ dein() {
   while [ $# -gt 0 ]; do
     case $1 in
     --overwrite-config | -oWC) KEEP_CONFIG=no ;;
-    *./* | */home/* | *~/*) BASE=$(eval echo "${1%/}") ;;
+    *./* | */home/* | *~/* | /Users/* ) BASE=$(eval echo "${1%/}") ;;
     --use-vim-config | -uVC)
       CONFIG_LOCATION="$HOME"
       CONFIG_FILENAME=".vimrc"


### PR DESCRIPTION
Mac環境で二重引用符を使わずにinstaller.shに~/.cache/deinをコマンドライン引数で渡すと、~が絶対パスに展開されてから渡されるが故に284行目のorの条件から漏れてしまうので、/Users/*という条件を追加しました。